### PR TITLE
Add bot support

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # List changed environment directories when PR is opened.
+      # List changed environment directories when PR is opened or updated by bots.
       - name: Get changed environments once
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || contains(github.actor, '[bot]')
         id: changed
         uses: tj-actions/changed-files@v35
         with:
@@ -50,9 +50,9 @@ jobs:
           json_raw_format: true
           json: true
 
-      # Add 'tf' prefixed labels for changed environments when PR is opened.
+      # Add 'tf' prefixed labels for changed environments when PR is opened or updated by bots.
       - name: Add changed environment labels once
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || contains(github.actor, '[bot]')
         uses: actions/github-script@v6
         env:
           changed: ${{ steps.changed.outputs.all_modified_files }}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, …)**
Support for adding labels to bot-generated PRs, such as "dependabot[bot]" dependency updates.

**What is the current behavior? (We can also link to an open issue here)**
Due to the nature of dependabot's PR, the default labelling process overrides and negates the benefit of auto-applying Terraform environment labels steps of the workflow. 
![image](https://user-images.githubusercontent.com/19497993/226372280-0ab9d060-cb02-4138-abbb-f5461acdd5f7.png)

**What is the new behavior? (If this is a feature change)**
By checking `contains(github.actor, '[bot]')` in addition to `github.event.action == 'opened'`, we should account for PRs like ones generated by dependabot. 

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No. 