### PR TITLE
Add labels only on relevant file changes

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,7 +40,7 @@ jobs:
 
       # List changed environment directories when PR is opened or updated by bots.
       - name: Get changed environments once
-        if: github.event.action == 'opened' || contains(github.actor, '[bot]')
+        if: contains(github.event.action, 'opened') || contains(github.actor, '[bot]')
         id: changed
         uses: tj-actions/changed-files@v35
         with:
@@ -52,7 +52,7 @@ jobs:
 
       # Add 'tf' prefixed labels for changed environments when PR is opened or updated by bots.
       - name: Add changed environment labels once
-        if: github.event.action == 'opened' || contains(github.actor, '[bot]')
+        if: steps.changed.outcome == 'success' && toJSON(fromJSON(steps.changed.outputs.all_modified_files)) != '[]'
         uses: actions/github-script@v6
         env:
           changed: ${{ steps.changed.outputs.all_modified_files }}
@@ -93,7 +93,7 @@ jobs:
   run:
     # Run terraform if one or more 'tf' prefixed labels are present.
     needs: [labels]
-    if: needs.labels.outputs.matrix != '' && toJSON(fromJSON(needs.labels.outputs.matrix)) != '[]'
+    if: toJSON(fromJSON(needs.labels.outputs.matrix)) != '[]'
     runs-on: ubuntu-latest
 
     # Run for each label and continue through to release state lock.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, …)**
Fixes labelling behaviour when a PR is opened with non-environment-related files modifications. 

**What is the current behavior? (We can also link to an open issue here)**
The add-labels step is run when it isn't required.

**What is the new behavior? (If this is a feature change)**
The add-labels step should only run if there are any relevant labels to add.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No. 